### PR TITLE
fixing navbar responsiveness on mobile

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,7 +1,7 @@
 .navbar-lewagon {
   justify-content: space-between;
   background: white;
-  height: $navbar-height;
+  // height: $navbar-height;
 }
 
 .navbar-lewagon .navbar-collapse {


### PR DESCRIPTION
Just fixed a bug with the height of the navbar.
Now we can display properly the responsive menu

<img width="493" alt="Capture d’écran 2020-08-18 à 17 22 05" src="https://user-images.githubusercontent.com/62642543/90532281-57e1e000-e177-11ea-86b1-fff0d9b86c9f.png">
