### PR TITLE
remove crop: fill for avatars because it makes them blurry

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -26,7 +26,7 @@
         <% if user_signed_in? %>
           <li class="nav-item dropdown ml-3">
             <% if current_user.photo.attached? %>
-              <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", width: 40, height: 40, crop: :fill, gravity: :face, id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+              <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", width: 40, height: 40, gravity: :face, id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <% else %>
               <%= image_tag "https://icon-library.com/images/default-user-icon/default-user-icon-8.jpg", class: "avatar dropdown-toggle", width: 40, height: 40, crop: :fill, gravity: :face, id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <% end %>

--- a/app/views/layouts/_tripcard.html.erb
+++ b/app/views/layouts/_tripcard.html.erb
@@ -23,7 +23,7 @@
 
     <!-- TRIP OWNER -->
     <% if trip.user.photo.attached? %>
-      <li class="list-inline-item"><%= cl_image_tag trip.user.photo.key, width: 40, height: 40, crop: :fill, gravity: :face, class: "avatar" %></li>
+      <li class="list-inline-item"><%= cl_image_tag trip.user.photo.key, width: 40, height: 40, gravity: :face, class: "avatar" %></li>
     <% else %>
       <li class="list-inline-item"><%= image_tag "https://icon-library.com/images/default-user-icon/default-user-icon-8.jpg", width: 40, height: 40, crop: :fill, gravity: :face, class: "avatar" %></li>
     <% end %>
@@ -32,7 +32,7 @@
     <% trip.bookings.each do |booking| %>
       <% if booking.accepted %>
         <% if booking.user.photo.attached? %>
-          <li class="list-inline-item"><%= cl_image_tag booking.user.photo.key, width: 40, height: 40, crop: :fill, gravity: :face, class: "avatar" %></li>
+          <li class="list-inline-item"><%= cl_image_tag booking.user.photo.key, width: 40, height: 40, gravity: :face, class: "avatar" %></li>
         <% else %>
           <li class="list-inline-item"><%= image_tag "https://icon-library.com/images/default-user-icon/default-user-icon-8.jpg", width: 40, height: 40, crop: :fill, gravity: :face, class: "avatar" %></li>
         <% end %>


### PR DESCRIPTION
remove crop: fill for avatars because it makes them blurry

before 
<img width="542" alt="Capture d’écran 2020-08-20 à 17 48 13" src="https://user-images.githubusercontent.com/62642543/90794659-534f3000-e30d-11ea-8340-4317504bf0db.png">


After
<img width="556" alt="Capture d’écran 2020-08-20 à 17 48 43" src="https://user-images.githubusercontent.com/62642543/90794720-64983c80-e30d-11ea-909d-747b64fb9951.png">
