### PR TITLE
Add flatpickr in trip/new

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@
 }
 @import 'mapbox-gl/dist/mapbox-gl';
 @import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder';
+@import "flatpickr/dist/themes/airbnb";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -38,3 +38,5 @@ document.addEventListener('turbolinks:load', () => {
   initMapbox();
 });
 
+import "../plugins/flatpickr"
+

--- a/app/javascript/plugins/flatpickr.js
+++ b/app/javascript/plugins/flatpickr.js
@@ -1,0 +1,21 @@
+import flatpickr from "flatpickr";
+
+
+const departureDate = document.getElementById('trip_departure_date');
+const returnDate = document.getElementById('trip_return_date');
+
+flatpickr(departureDate, {
+  altInput: true,
+  minDate: new Date().fp_incr(1), // 1 day from now
+
+});
+
+departureDate.addEventListener('change', (event) => {
+  flatpickr(returnDate, {
+  altInput: true,
+  minDate: new Date(event.target.value).fp_incr(1), // 2 days from now
+});
+
+})
+
+

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -7,8 +7,8 @@
       <%= f.input :destination %>
       <%= f.input :budget_min %>
       <%= f.input :budget_max %>
-      <%= f.input :departure_date %>
-      <%= f.input :return_date %>
+      <%= f.input :departure_date, as: :string %>
+      <%= f.input :return_date,as: :string %>
       <%= f.input :capacity %>
       <%= f.input :photo, as: :file, required: true %>
       <%= f.submit "Submit Trip", class: "btn-travel" %>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "^4.5.2",
+    "flatpickr": "^4.6.6",
     "jquery": "^3.5.1",
     "mapbox-gl": "^1.12.0",
     "places.js": "^1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,6 +3297,11 @@ findup-sync@^3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flatpickr@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.6.tgz#34d2ad80adfa34254e62583a34264d472f1038d6"
+  integrity sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A==
+
 flatted@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"


### PR DESCRIPTION
Added flatpickr for the fields `departure_date` and `return_date` in the simple_form located on trip/new.
For a better UI/UX, user cannot select a return date that is < to the departure_date.

Dont forget to yarn install

<img width="627" alt="Capture d’écran 2020-08-21 à 12 13 36" src="https://user-images.githubusercontent.com/62642543/90879801-be4d4500-e3a7-11ea-969a-ddcc4d31a90f.png">
